### PR TITLE
Chortdefinition viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,8 @@
 											<!-- ko if: isRunning -->
 											<img class="spin" src="images/running.png" />Generating...
 											<!-- /ko -->
-											<!-- /ko -->											
+											<!-- /ko -->
+											<button class="button button-small button-flat-primary" data-bind="click: showSql">Show SQL</button>
 										</td>
 									</tr>
 									<tr>
@@ -146,32 +147,6 @@
 									</div>
 								</div>
 							</div>
-							<button data-bind="click: showSql">Show SQL</button>
-							<!-- ko if: sqlOptions() != null -->
-							<table>
-								<tr>
-									<td>CDM Schema:</td>
-									<td><input data-bind="value: sqlOptions().cdmSchema"></input></td>
-								</tr>
-								<tr>
-									<td>Target Schema:</td>
-									<td><input data-bind="value: sqlOptions().targetSchema"></input></td>
-								</tr>
-								<tr>
-									<td>Target Table:</td>
-									<td><input data-bind="value: sqlOptions().targetTable"></input></td>
-								</tr>
-								<tr>
-									<td>Cohort Def Id:</td>
-									<td><input data-bind="value: sqlOptions().cohortId"></input></td>
-								</tr>
-							</table>
-							<button data-bind="click: removeSqlOptions">Remove Options</button>
-							<!-- /ko -->
-							<!-- ko if: sqlOptions() == null -->
-							<button data-bind="click: addSqlOptions">Add Options</button>
-							<!-- /ko -->
-
 						</div>
 					</td>
 				</tr>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 								</div>
 								<div data-bind="attr: { id: 'printfriendly' }">
 									<div style="padding: 5px">
-										Print friendly version of cohort criteria here.
+										<cohort-expression-viewer params="expression: selectedDefinition().expression"></cohort-expression-viewer>
 									</div>
 								</div>
 								<div data-bind="attr: { id: 'raw' }">

--- a/js/app.js
+++ b/js/app.js
@@ -12,9 +12,9 @@ define(['jquery',
 				'css!styles/buttons.css',
 				'databindings',
 				'circe',
+				'cohortdefinitionviewer',
 				'bindings/jqAutosizeBinding'
-			 ],
-	function (
+], function (
 		$,
 		ko,
 		config,

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,10 @@ requirejs.config({
 		{
 			name: "circe",
 			location: "modules/circe"
+		},
+		{
+			name: "cohortdefinitionviewer",
+			location: "modules/cohortdefinitionviewer"
 		}
 	],
 	paths: {

--- a/js/modules/cohortbuilder/CohortExpression.js
+++ b/js/modules/cohortbuilder/CohortExpression.js
@@ -5,14 +5,27 @@ define(function (require, exports) {
 	var ConceptSet = require('conceptsetbuilder/InputTypes/ConceptSet');
 	var PrimaryCriteria = require('./PrimaryCriteria');
 
+	function conceptSetSorter(a,b)
+	{
+		var textA = a.name().toUpperCase();
+		var textB = b.name().toUpperCase();
+		return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+	}
+	
 	function CohortExpression(data) {
 		var self = this;
 		var data = data || {};
 
+		
 		self.PrimaryCriteria = ko.observable(new PrimaryCriteria(data.PrimaryCriteria));
 		self.AdditionalCriteria = ko.observable(data.AdditionalCriteria && new CriteriaGroup(data.AdditionalCriteria));
 		self.ConceptSets = ko.observableArray(data.ConceptSets && data.ConceptSets.map(function(d) { return new ConceptSet(d) }));
 		self.ExpressionLimit =  { Type: ko.observable(data.ExpressionLimit && data.ExpressionLimit.Type || "All") }
+		
+		self.ConceptSets.sorted = ko.pureComputed(function() {
+			return self.ConceptSets().map(function (item) { return item; }).sort(conceptSetSorter);
+		});
+	
 		
 	}
 	return CohortExpression;

--- a/js/modules/cohortbuilder/CriteriaTypes/ConditionOccurrence.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/ConditionOccurrence.js
@@ -15,7 +15,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 			return new Concept(d);
 		})));
 		self.StopReason = ko.observable(data.StopReason && new Text(data.StopReason));
-		self.ConditionSourceConcept = ko.observable(data.ConditionSourceConcept && ko.observable(data.ConditionSourceConcept));
+		self.ConditionSourceConcept = ko.observable(data.ConditionSourceConcept != null ? ko.observable(data.ConditionSourceConcept) : null);
 
 		// Derived Fields
 		self.First = ko.observable(data.First || null);

--- a/js/modules/cohortbuilder/CriteriaTypes/Death.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/Death.js
@@ -13,7 +13,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 		self.DeathType = ko.observable(data.DeathType && ko.observableArray(data.DeathType.map(function (d) {
 			return new Concept(d);
 		})));
-		self.DeathSourceConcept = ko.observable(data.CauseSourceConcept && ko.observable(data.CauseSourceConcept));
+		self.DeathSourceConcept = ko.observable(data.DeathSourceConcept != null ? ko.observable(data.DeathSourceConcept) : null);
 		// Derived Fields
 		self.Age = ko.observable(data.Age && new Range(data.Age));
 

--- a/js/modules/cohortbuilder/CriteriaTypes/DeviceExposure.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/DeviceExposure.js
@@ -16,7 +16,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 		})));
 		self.UniqueDeviceId = ko.observable(data.UniqueDeviceId && new Text(data.StopReason));
 		self.Quantity = ko.observable(data.Quantity && new Range(data.Quantity));
-		self.DeviceSourceConcept = ko.observable(data.DeviceSourceConcept && ko.observable(data.DeviceSourceConcept));
+		self.DeviceSourceConcept = ko.observable(data.DeviceSourceConcept != null ? ko.observable(data.DeviceSourceConcept) : null);
 
 		// Derived Fields
 		self.First = ko.observable(data.First || null);

--- a/js/modules/cohortbuilder/CriteriaTypes/DrugExposure.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/DrugExposure.js
@@ -26,7 +26,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 			return new Concept(d);
 		})));
 		self.LotNumber = ko.observable(data.LotNumber && new Text(data.LotNumber));
-		self.DrugSourceConcept = ko.observable(data.DrugSourceConcept && ko.observable(data.DrugSourceConcept));
+		self.DrugSourceConcept = ko.observable(data.DrugSourceConcept != null ? ko.observable(data.DrugSourceConcept) : null);
 
 		// Derived Fields
 		self.First = ko.observable(data.First || null);

--- a/js/modules/cohortbuilder/CriteriaTypes/Measurement.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/Measurement.js
@@ -25,7 +25,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 		}))); 
 		self.RangeLow = ko.observable(data.RangeLow && new Range(data.RangeLow));
 		self.RangeHigh = ko.observable(data.RangeHigh && new Range(data.RangeHigh));
-		self.MeasurementSourceConcept = ko.observable(data.MeasurementSourceConcept && ko.observable(data.MeasurementSourceConcept));
+		self.MeasurementSourceConcept = ko.observable(data.MeasurementSourceConcept != null ? ko.observable(data.MeasurementSourceConcept) : null);
 		
 		// Derived Fields
 		self.RangeLowRatio = ko.observable(data.RangeLowRatio && new Range(data.RangeLowRatio));

--- a/js/modules/cohortbuilder/CriteriaTypes/Observation.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/Observation.js
@@ -24,7 +24,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 		self.Unit = ko.observable(data.Unit && ko.observableArray(data.Unit.map(function (d) {
 			return new Concept(d);
 		})));
-		self.ObservationSourceConcept = ko.observable(data.ObservationSourceConcept && ko.observable(data.ObservationSourceConcept));
+		self.ObservationSourceConcept = ko.observable(data.ObservationSourceConcept != null ? ko.observable(data.ObservationSourceConcept) : null);
 
 		// Derived Fields
 		self.First = ko.observable(data.First || null);

--- a/js/modules/cohortbuilder/CriteriaTypes/ProcedureOccurrence.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/ProcedureOccurrence.js
@@ -20,7 +20,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept'], f
 		
 		self.Quantity = ko.observable(data.Quantity && new Range(data.Quantity));
 		
-		self.ProcedureSourceConcept = ko.observable(data.ProcedureSourceConcept && ko.observable(data.ProcedureSourceConcept));
+		self.ProcedureSourceConcept = ko.observable(data.ProcedureSourceConcept != null ? ko.observable(data.ProcedureSourceConcept) : null);
 
 		// Derived Fields
 		self.First = ko.observable(data.First || null);

--- a/js/modules/cohortbuilder/CriteriaTypes/VisitOccurrence.js
+++ b/js/modules/cohortbuilder/CriteriaTypes/VisitOccurrence.js
@@ -14,7 +14,7 @@ define(['knockout', '../InputTypes/Range','conceptpicker/InputTypes/Concept', '.
 		self.VisitType = ko.observable(data.VisitType && ko.observableArray(data.VisitType.map(function (d) {
 			return new Concept(d);
 		})));
-		self.VisitSourceConcept = ko.observable(data.VisitSourceConcept && ko.observable(data.VisitSourceConcept));
+		self.VisitSourceConcept = ko.observable(data.VisitSourceConcept != null ? ko.observable(data.VisitSourceConcept) : null);
 		self.VisitLength = ko.observable(data.VisitLength && new Range(data.VisitLength));
 
 		// Derived Fields

--- a/js/modules/cohortbuilder/InputTypes/Range.js
+++ b/js/modules/cohortbuilder/InputTypes/Range.js
@@ -12,8 +12,8 @@ define(['knockout'], function (ko) {
 
 	Range.prototype.toJSON = function () {
 		return {
-			Value : this.Value instanceof Date ? (this.Value.getFullYear() + '-' + (this.Value.getMonth() + 1) + '-' + this.Value.getDate() ) : this.Value,
-			Extent: this.Extent instanceof Date ? (this.Extent.getFullYear() + '-' + (this.Extent.getMonth() + 1) + '-' + this.Extent.getDate() ) : this.Extent,
+			Value : this.Value instanceof Date ? (this.Value.toISOString().slice(0,10)) : this.Value,
+			Extent: this.Extent instanceof Date ? (this.Extent.toISOString().slice(0,10)) : this.Extent,
 			Op: this.Op
 		}
 	}

--- a/js/modules/cohortbuilder/components/ConditionEraTemplate.html
+++ b/js/modules/cohortbuilder/components/ConditionEraTemplate.html
@@ -5,7 +5,7 @@
 			<col />							
 			<tr>
 				<td colspan="2"> a condition era of 
-					<select data-bind="options: $component.expression.ConceptSets, 
+					<select data-bind="options: $component.expression.ConceptSets.sorted, 
 						optionsText: function(item) { return item.name }, 
 						optionsCaption: 'Any Condition', 
 						optionsValue: 'id',

--- a/js/modules/cohortbuilder/components/ConditionOccurrenceTemplate.html
+++ b/js/modules/cohortbuilder/components/ConditionOccurrenceTemplate.html
@@ -5,7 +5,7 @@
 			<col />							
 			<tr>
 				<td colspan="2"> a condition occurrence of 
-					<select data-bind="options: $component.expression.ConceptSets, 
+					<select data-bind="options: $component.expression.ConceptSets.sorted, 
 						optionsText: function(item) { return item.name }, 
 						optionsCaption: 'Any Condition', 
 						optionsValue: 'id',

--- a/js/modules/cohortbuilder/components/MeasurementTemplate.html
+++ b/js/modules/cohortbuilder/components/MeasurementTemplate.html
@@ -136,7 +136,7 @@
 			<tr data-bind="if: VisitType() != null, visible: VisitType() != null">
 				<td><img data-bind="click: function() { $component.removeCriterion('VisitType') }" class="deleteIcon" src="images/cohortbuilder/delete.png" /></td>
 				<td>
-					with a Visit occurrance of: <concept-list params="PickerParams: { DefaultDomain: 'Visit', DefaultQuery: ''}, ConceptList: VisitType()"></concept-list>
+					with a Visit of: <concept-list params="PickerParams: { DefaultDomain: 'Visit', DefaultQuery: ''}, ConceptList: VisitType()"></concept-list>
 				</td>									
 			</tr>								
 		</table>

--- a/js/modules/cohortbuilder/options.js
+++ b/js/modules/cohortbuilder/options.js
@@ -17,13 +17,13 @@ define([], function () {
 
 	options.occurrenceTypeOptions = [{
 		id: 1,
-		name: 'At Most'
+		name: 'at most'
 }, {
 		id: 0,
-		name: 'Exactly'
+		name: 'exactly'
 }, {
 		id: 2,
-		name: 'At Least'
+		name: 'at least'
 }];
 
 	options.windowDayOptions = new Array();
@@ -55,13 +55,13 @@ define([], function () {
 }];
 	
 	options.resultLimitOptions = [{
-				name: "All Events",
+				name: "all events",
 				id: "All"
 		}, {
-				name: "Earliest Event",
+				name: "earliest event",
 				id: "First"
 		}, {
-				name: "Latest Event",
+				name: "latest event",
 				id: "Last"
 		}];
 	

--- a/js/modules/cohortdefinitionviewer/components/CohortExpressionViewer.js
+++ b/js/modules/cohortdefinitionviewer/components/CohortExpressionViewer.js
@@ -1,0 +1,54 @@
+define(['knockout', 'cohortbuilder/options', 'text!./CohortExpressionViewerTemplate.html'], 
+			 function (ko, options, template) {
+		
+	function CohortExpressionEditorViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.options = options;
+
+		self.getLimitTypeText = function(typeId)
+		{
+			return options.resultLimitOptions.filter(function (item) {
+				return item.id == typeId;
+			})[0].name;
+		}
+		self.getCriteriaIndexComponent = function (data) {
+			data = ko.utils.unwrapObservable(data);
+			if (data.hasOwnProperty("ConditionOccurrence"))
+				return "condition-occurrence-criteria-viewer";
+			else if (data.hasOwnProperty("ConditionEra"))
+				return "condition-era-criteria-viewer";
+			else if (data.hasOwnProperty("DrugExposure"))
+				return "drug-exposure-criteria-viewer";
+			else if (data.hasOwnProperty("DrugEra"))
+				return "drug-era-criteria-viewer";
+			else if (data.hasOwnProperty("DoseEra"))
+				return "dose-era-criteria-viewer";
+			else if (data.hasOwnProperty("ProcedureOccurrence"))
+				return "procedure-occurrence-criteria-viewer";
+			else if (data.hasOwnProperty("Observation"))
+				return "observation-criteria-viewer";			
+			else if (data.hasOwnProperty("VisitOccurrence"))
+				return "visit-occurrence-criteria-viewer";			
+			else if (data.hasOwnProperty("DeviceExposure"))
+				return "device-exposure-criteria-viewer";			
+			else if (data.hasOwnProperty("Measurement"))
+				return "measurement-criteria-viewer";
+			else if (data.hasOwnProperty("Specimen"))
+				return "specimen-criteria-viewer";
+			else if (data.hasOwnProperty("ObservationPeriod"))
+				return "observation-period-criteria-viewer";			
+			else if (data.hasOwnProperty("Death"))
+				return "death-criteria-viewer";			
+			else
+				return "unknownCriteriaType";
+		};
+	}
+
+	// return factory
+	return {
+		viewModel: CohortExpressionEditorViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
@@ -12,7 +12,7 @@ People having any of the following:<br>
 <span data-bind="with: expression().PrimaryCriteria().ObservationWindow"> with observation at least
 	<span class="numericField" data-bind="text: PriorDays.numeric()" /> days prior and <span class="numericField" data-bind="text: PostDays.numeric()" /> days after index,
 </span>
-<span data-bind="with: expression().PrimaryCriteria().PrimaryCriteriaLimit"> and limit primary events to: <span style="font-weight: bold"><span data-bind="text: $component.getLimitTypeText(Type())"></span> per person.</span></span>
+<span data-bind="with: expression().PrimaryCriteria().PrimaryCriteriaLimit"> and limit primary events to: <b><span data-bind="text: $component.getLimitTypeText(Type())"></span> per person.</b></span>
 </div>
 <br/>
 
@@ -24,3 +24,13 @@ People having any of the following:<br>
 </div>
 
 <div data-bind="with: expression().ExpressionLimit">Limit cohort expression results to: <b><span data-bind="text: $component.getLimitTypeText(Type())"></span> per person.</b></div>
+<br/>
+<div style="font-size:1.3em">Appendix 1: Concept Set Definitions</div>
+<br/>
+<!-- ko foreach: expression().ConceptSets.sorted -->
+<div style="font-size: 1.15em"><span data-bind="text: ($index() + 1)"></span>. <span data-bind="text: $data.name"></span></div>
+<div style="padding-left:20px">
+<conceptset-viewer params="{conceptSet: $data}"></conceptset-viewer>
+<br/>
+</div>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/CohortExpressionViewerTemplate.html
@@ -1,0 +1,26 @@
+People having any of the following:<br>
+
+<ul>
+<!-- ko foreach: expression().PrimaryCriteria().CriteriaList -->
+	<li><div data-bind='component: { 
+						name: $component.getCriteriaIndexComponent($data),
+						params: {expression: $component.expression(), criteria: $data} }'></div>
+	</li>
+<!-- /ko -->
+</ul>
+<div>
+<span data-bind="with: expression().PrimaryCriteria().ObservationWindow"> with observation at least
+	<span class="numericField" data-bind="text: PriorDays.numeric()" /> days prior and <span class="numericField" data-bind="text: PostDays.numeric()" /> days after index,
+</span>
+<span data-bind="with: expression().PrimaryCriteria().PrimaryCriteriaLimit"> and limit primary events to: <span style="font-weight: bold"><span data-bind="text: $component.getLimitTypeText(Type())"></span> per person.</span></span>
+</div>
+<br/>
+
+<div data-bind="with: expression">
+	<div data-bind="if: AdditionalCriteria">
+		<div style="font-weight: bold">For people matching the Primary Events, include:</div>
+		<criteria-group-viewer params="{expression: $data, group: AdditionalCriteria}"></criteria-group-viewer>
+	</div>
+</div>
+
+<div data-bind="with: expression().ExpressionLimit">Limit cohort expression results to: <b><span data-bind="text: $component.getLimitTypeText(Type())"></span> per person.</b></div>

--- a/js/modules/cohortdefinitionviewer/components/ConceptList.js
+++ b/js/modules/cohortdefinitionviewer/components/ConceptList.js
@@ -1,0 +1,18 @@
+define(['knockout','text!./ConceptListTemplate.html', 'conceptpicker/InputTypes/Concept'], function (ko, template, Concept) {
+
+	function CocneptListViewModel(params) {
+		var self = this;
+		self.ConceptList = ko.utils.unwrapObservable(params.$raw.ConceptList);
+		self.PickerParams = params.PickerParams;
+		
+		self.ConceptListNames = ko.pureComputed(function () {
+			return self.ConceptList().map(function(item) { return item.CONCEPT_NAME }).join(', ');
+		});
+	}
+	
+	// return compoonent definition
+	return {
+		viewModel: CocneptListViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ConceptListTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConceptListTemplate.html
@@ -1,0 +1,1 @@
+<span data-bind="text: ConceptListNames"></span>

--- a/js/modules/cohortdefinitionviewer/components/ConceptSetReference.js
+++ b/js/modules/cohortdefinitionviewer/components/ConceptSetReference.js
@@ -1,0 +1,35 @@
+define(['knockout','text!./ConceptSetReferenceTemplate.html'], function (ko, template) {
+
+	function ConceptSetReference(params) {
+		var self = this;
+		self.conceptSetId =params.conceptSetId;
+		self.conceptSets = params.conceptSets;
+		self.defaultName = params.defaultName;
+		
+		self.referenceId = ko.pureComputed(function () {
+			var calculatedRefId = "";
+			if (self.conceptSetId() != null)
+			{
+				var selectedConceptSet = self.conceptSets().filter(function(item) { return item.id == self.conceptSetId(); })[0];
+				calculatedRefId = (self.conceptSets.sorted().indexOf(selectedConceptSet) + 1) + "";
+			}
+			return calculatedRefId;
+		});
+		
+		self.codesetName = ko.pureComputed(function () {
+			if (self.conceptSetId() != null)
+			{
+				var selectedConceptSet = self.conceptSets().filter(function (item) { return item.id == self.conceptSetId()})[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
+			else
+				return self.defaultName;
+		});
+	}
+	
+	// return compoonent definition
+	return {
+		viewModel: ConceptSetReference,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ConceptSetReferenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConceptSetReferenceTemplate.html
@@ -1,0 +1,1 @@
+<span data-bind="text: codesetName"></span><span style="vertical-align: super" data-bind="text: referenceId"></span>

--- a/js/modules/cohortdefinitionviewer/components/ConceptSetViewer.js
+++ b/js/modules/cohortdefinitionviewer/components/ConceptSetViewer.js
@@ -1,0 +1,14 @@
+define(['knockout','text!./ConceptSetViewerTemplate.html'], function (ko, template) {
+
+	function ConceptSetViewer(params) {
+		var self = this;
+		self.conceptSet = params.conceptSet;
+		
+	}
+	
+	// return compoonent definition
+	return {
+		viewModel: ConceptSetViewer,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ConceptSetViewerTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConceptSetViewerTemplate.html
@@ -1,0 +1,24 @@
+<table width="100%">
+	<thead>
+		<tr>
+			<th>Concept Id</th>
+			<th>Concept Name</th>
+			<th>Domain</th>
+			<th>Vocabulary</th>
+			<th style="font-size: .65em">Exclude</th>
+			<th style="font-size: .65em">Descendants</th>
+			<th style="font-size: .65em">Mapped</th>
+		</tr>
+	</thead>
+	<tbody data-bind="foreach: conceptSet.expression.items">
+		<tr>
+			<td data-bind="text: concept.CONCEPT_ID"></td>
+			<td data-bind="text: concept.CONCEPT_NAME"></td>
+			<td data-bind="text: concept.DOMAIN_ID"></td>
+			<td data-bind="text: concept.VOCABULARY_ID"></td>
+			<td data-bind="text: isExcluded() ? 'YES' : 'NO'"></td>
+			<td data-bind="text: includeDescendants() ? 'YES' : 'NO'"></td>
+			<td data-bind="text: includeMapped() ? 'YES' : 'NO'"></td>
+		</tr>
+	</tbody>
+</table>

--- a/js/modules/cohortdefinitionviewer/components/ConditionEra.js
+++ b/js/modules/cohortdefinitionviewer/components/ConditionEra.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/ConditionEra.js
+++ b/js/modules/cohortdefinitionviewer/components/ConditionEra.js
@@ -1,0 +1,23 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'text!./ConditionEraTemplate.html'], function (ko, options, Range, template) {
+
+	function ConditionEraViewModel(params) {
+		
+		var self = this;
+		self.expression = params.expression;
+		self.Criteria = params.criteria.ConditionEra;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: ConditionEraViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ConditionEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConditionEraTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a condition era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Condition')"></span>
+a condition era of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Condition'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/ConditionEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConditionEraTemplate.html
@@ -1,0 +1,29 @@
+<!-- ko with: Criteria -->
+a condition era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Condition')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: EraStartDate() != null -->
+	<li>era start is <date-range-viewer params="Range: EraStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraEndDate() != null -->
+	<li>era end is <date-range-viewer params="Range: EraEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceCount() != null -->
+	<li>with occurrence count <numeric-range-viewer params="Range: OccurrenceCount"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraLength() != null -->
+	<li>with era length <numeric-range-viewer params="Range: EraLength"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtStart() != null -->
+	<li>with age at era start <numeric-range-viewer params="Range: AgeAtStart"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtEnd() != null -->
+	<li>with age at era end <numeric-range-viewer params="Range: AgeAtEnd"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/ConditionOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/ConditionOccurrence.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/ConditionOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/ConditionOccurrence.js
@@ -1,0 +1,23 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./ConditionOccurrenceTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function ConditionOccurrenceViewModel(params) {
+
+		var self = this;
+		self.expression = params.expression;
+		self.Criteria = params.criteria.ConditionOccurrence;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: ConditionOccurrenceViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ConditionOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConditionOccurrenceTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a condition occurrence of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Condition')"></span>
+a condition occurrence of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Condition'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>
@@ -17,7 +17,7 @@ a condition occurrence of <span data-bind="text: $component.getCodesetName(Codes
 	<li>with a Stop Reason <text-filter-viewer params="Filter: StopReason"></text-filter-viewer></li>
 <!-- /ko -->
 <!-- ko if: ConditionSourceConcept() != null -->
-	<li>Condition Source Concept is <span data-bind="text: $component.getCodesetName(ConditionSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Condition Source Concept is <conceptset-reference params="{conceptSetId: ConditionSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: Age() != null -->
 	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/ConditionOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ConditionOccurrenceTemplate.html
@@ -1,0 +1,35 @@
+<!-- ko with: Criteria -->
+a condition occurrence of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Condition')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceEndDate() != null -->
+	<li>occurrence end is <date-range-viewer params="Range: OccurrenceEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ConditionType() != null -->
+	<li>condition type is any of: <concept-list-viewer params="ConceptList: ConditionType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: StopReason() != null -->
+	<li>with a Stop Reason <text-filter-viewer params="Filter: StopReason"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: ConditionSourceConcept() != null -->
+	<li>Condition Source Concept is <span data-bind="text: $component.getCodesetName(ConditionSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/CriteriaGroup.js
+++ b/js/modules/cohortdefinitionviewer/components/CriteriaGroup.js
@@ -1,0 +1,65 @@
+define(['knockout', 'cohortbuilder/CriteriaTypes','cohortbuilder/CriteriaGroup', 'cohortbuilder/AdditionalCriteria', 'cohortbuilder/options', 'text!./CriteriaGroupTemplate.html'], function (ko, criteriaTypes, CriteriaGroup, AdditionalCriteria, options, template) {
+
+	function CriteriaGroupViewModel(params) {
+		var self = this;
+
+		self.expression = ko.utils.unwrapObservable(params.expression);
+		self.group = params.group;
+		self.parentGroup = params.parentGroup;
+		self.options = options;
+
+		self.getCriteriaComponent = function (data) {
+
+			if (data.hasOwnProperty("Person"))
+				return "person-criteria";
+			else if (data.hasOwnProperty("ConditionOccurrence"))
+				return "condition-occurrence-criteria-viewer";
+			else if (data.hasOwnProperty("ConditionEra"))
+				return "condition-era-criteria-viewer";
+			else if (data.hasOwnProperty("DrugExposure"))
+				return "drug-exposure-criteria-viewer";
+			else if (data.hasOwnProperty("DrugEra"))
+				return "drug-era-criteria-viewer";
+			else if (data.hasOwnProperty("DoseEra"))
+				return "dose-era-criteria-viewer";
+			else if (data.hasOwnProperty("ProcedureOccurrence"))
+				return "procedure-occurrence-criteria-viewer";
+			else if (data.hasOwnProperty("VisitOccurrence"))
+				return "visit-occurrence-criteria-viewer";
+			else if (data.hasOwnProperty("Observation"))
+				return "observation-criteria-viewer";
+			else if (data.hasOwnProperty("DeviceExposure"))
+				return "device-exposure-criteria-viewer";
+			else if (data.hasOwnProperty("Measurement"))
+				return "measurement-criteria-viewer";
+			else if (data.hasOwnProperty("Specimen"))
+				return "specimen-criteria-viewer";
+			else if (data.hasOwnProperty("ObservationPeriod"))
+				return "observation-period-criteria-viewer";			
+			else if (data.hasOwnProperty("Death"))
+				return "death-criteria-viewer";
+			else
+				return "unknown-criteria";
+		};
+		
+		self.groupType = ko.pureComputed(function() {
+			return self.options.groupTypeOptions.filter(function(item) {
+				return item.id == self.group().Type();
+			})[0].name;
+		});
+		
+		self.getOccurrenceType = function(occurenceType) {
+			return self.options.occurrenceTypeOptions.filter(function(item) {
+				return item.id == occurenceType;
+			})[0].name;
+		};
+		
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: CriteriaGroupViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/CriteriaGroupTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/CriteriaGroupTemplate.html
@@ -1,0 +1,28 @@
+<span data-bind="if: parentGroup">
+	<span data-bind="	if: (parentGroup().CriteriaList().length > 0) || parentGroup().Groups().indexOf(group()) > 0"><span data-bind="	text: parentGroup().Type() == 'ALL' ? 'And' : 'Or'"></span> people having</span>
+	<span data-bind="	ifnot: (parentGroup().CriteriaList().length > 0) || parentGroup().Groups().indexOf(group()) > 0">People having</span>
+</span>
+<span data-bind="ifnot: parentGroup">People having</span> <span data-bind="text: groupType"></span> of the following criteria:
+<ul>
+<!-- ko foreach: group().CriteriaList -->
+	<li>
+		<span data-bind="if: ($index() > 0)"><span data-bind="	text: $component.group().Type() == 'ALL' ? 'and ' : 'or '"></span></span>
+		<span data-bind="text: $component.getOccurrenceType(Occurrence.Type())" /> <span data-bind="text: Occurrence.Count"></span> <span data-bind="text: Occurrence.IsDistinct() ? 'distinct' : ''"></span>
+		occurrence<span data-bind="text: Occurrence.Count != 1 ? 's' : ''"></span> of
+		<span data-bind="component: { 
+							name: $component.getCriteriaComponent($data.Criteria), 
+							params: {expression: $component.expression, criteria: $data.Criteria }
+						}"></span>
+		occurring between <window-input-viewer params="Window: StartWindow"></window-input-viewer> index		
+	</li>		
+<!-- /ko -->
+</ul>	
+<ul>
+<!-- ko foreach: group().Groups -->
+	<li>
+		<div style="padding-top: 5px; position:relative">
+			<criteria-group-viewer params="{expression: $component.expression, group: ko.observable($data), parentGroup: $parent.group()}"></criteria-group-viewer>
+		</div>
+	</li>
+<!-- /ko -->
+</ul>

--- a/js/modules/cohortdefinitionviewer/components/DateRange.js
+++ b/js/modules/cohortdefinitionviewer/components/DateRange.js
@@ -1,0 +1,43 @@
+define(['knockout', 'text!./DateRangeTemplate.html'], function (ko, componentTemplate) {
+
+	function DateRangeViewModel(params) {
+		var self = this;
+		self.Range = params.Range; // this will be a NumericRange input type.
+		
+		self.operationOptions = [{
+			id: 'lt',
+			name: 'before'
+		}, {
+			id: 'lte',
+			name: 'on or Before'
+		}, {
+			id: 'eq',
+			name: 'on'
+		}, {
+			id: 'gt',
+			name: 'after'
+		}, {
+			id: 'gte',
+			name: 'on or after'
+		}, {
+			id: 'bt',
+			name: 'between'
+		}, {
+			id: '!bt',
+			name: 'not between'
+		}];
+		
+		self.rangeOpName = ko.pureComputed(function() {
+			return self.operationOptions.filter(function(item) {
+				return item.id == self.Range().Op();
+			})[0].name;
+		});
+	};
+
+	// return compoonent definition
+	return {
+		viewModel: DateRangeViewModel,
+		template: componentTemplate
+	};
+
+});

--- a/js/modules/cohortdefinitionviewer/components/DateRangeTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DateRangeTemplate.html
@@ -1,0 +1,1 @@
+<span class="readOnlyField" data-bind="text: rangeOpName"></span> <span class="readOnlyField" data-bind="text: Range().Value"></span><span data-bind="if: Range().Op().substr(-2) == 'bt'"> and <span class="readOnlyField" data-bind="text: Range().Extent"></span>

--- a/js/modules/cohortdefinitionviewer/components/Death.js
+++ b/js/modules/cohortdefinitionviewer/components/Death.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/Death.js
+++ b/js/modules/cohortdefinitionviewer/components/Death.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./DeathTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function DeathViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.Death;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: DeathViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/DeathTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DeathTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a death occurrence from <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a death occurrence from <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Death'}"></conceptset-reference>
 <ul>
 <!-- ko if: OccurrenceStartDate() != null -->
 	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
@@ -8,7 +8,7 @@ a death occurrence from <span data-bind="text: $component.getCodesetName(Codeset
 	<li>death type is any of: <concept-list-viewer params="ConceptList: DeathType()"></concept-list-viewer></li>
 <!-- /ko -->
 <!-- ko if: DeathSourceConcept() != null -->
-	<li>Death Source Concept is <span data-bind="text: $component.getCodesetName(DeathSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Death Source Concept is <conceptset-reference params="{conceptSetId: DeathSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: Age() != null -->
 	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/DeathTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DeathTemplate.html
@@ -1,0 +1,20 @@
+<!-- ko with: Criteria -->
+a death occurrence from <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: DeathType() != null -->
+	<li>death type is any of: <concept-list-viewer params="ConceptList: DeathType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: DeathSourceConcept() != null -->
+	<li>Death Source Concept is <span data-bind="text: $component.getCodesetName(DeathSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/DeviceExposure.js
+++ b/js/modules/cohortdefinitionviewer/components/DeviceExposure.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/DeviceExposure.js
+++ b/js/modules/cohortdefinitionviewer/components/DeviceExposure.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./DeviceExposureTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function DeviceExposureViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.DeviceExposure;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: DeviceExposureViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/DeviceExposureTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DeviceExposureTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a device exposure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Device')"></span>
+a device exposure of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Device'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/DeviceExposureTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DeviceExposureTemplate.html
@@ -1,0 +1,35 @@
+<!-- ko with: Criteria -->
+a device exposure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Device')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceEndDate() != null -->
+	<li>occurrence end is <date-range-viewer params="Range: OccurrenceEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: DeviceType() != null -->
+	<li>device type is any of: <concept-list-viewer params="ConceptList: DeviceType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: UniqueDeviceId() != null -->
+	<li>with a unique device id <text-filter-viewer params="Filter: UniqueDeviceId"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: Quantity() != null -->
+	<li>with quantity <numeric-range-viewer params="Range: Quantity"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/DoseEra.js
+++ b/js/modules/cohortdefinitionviewer/components/DoseEra.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'text!./DoseEraTemplate.html'], function (ko, options, Range, template) {
+
+	function DoseEraViewModel(params) {
+		
+		var self = this;
+		self.expression = params.expression;
+		self.Criteria = params.criteria.DoseEra;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: DoseEraViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/DoseEra.js
+++ b/js/modules/cohortdefinitionviewer/components/DoseEra.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/DoseEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DoseEraTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a dose era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a dose era of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Drug'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/DoseEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DoseEraTemplate.html
@@ -1,0 +1,32 @@
+<!-- ko with: Criteria -->
+a dose era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: EraStartDate() != null -->
+	<li>era start is <date-range-viewer params="Range: EraStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraEndDate() != null -->
+	<li>era end is <date-range-viewer params="Range: EraEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Unit() != null -->
+	<li>unit is any of: <concept-list-viewer params="ConceptList: Unit()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: DoseValue() != null -->
+	<li>with dose value <numeric-range-viewer params="Range: DoseValue"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraLength() != null -->
+	<li>with era length <numeric-range-viewer params="Range: EraLength"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtStart() != null -->
+	<li>with age at era start <numeric-range-viewer params="Range: AgeAtStart"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtEnd() != null -->
+	<li>with age at era end <numeric-range-viewer params="Range: AgeAtEnd"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/DrugEra.js
+++ b/js/modules/cohortdefinitionviewer/components/DrugEra.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'text!./DrugEraTemplate.html'], function (ko, options, Range, template) {
+
+	function DrugEraViewModel(params) {
+		
+		var self = this;
+		self.expression = params.expression;
+		self.Criteria = params.criteria.DrugEra;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: DrugEraViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/DrugEra.js
+++ b/js/modules/cohortdefinitionviewer/components/DrugEra.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/DrugEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DrugEraTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a drug era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a drug era of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Drug'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/DrugEraTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DrugEraTemplate.html
@@ -1,0 +1,32 @@
+<!-- ko with: Criteria -->
+a drug era of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: EraStartDate() != null -->
+	<li>era start is <date-range-viewer params="Range: EraStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraEndDate() != null -->
+	<li>era end is <date-range-viewer params="Range: EraEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceCount() != null -->
+	<li>with exposure count <numeric-range-viewer params="Range: OccurrenceCount"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: GapDays() != null -->
+	<li>with gap days <numeric-range-viewer params="Range: GapDays"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: EraLength() != null -->
+	<li>with era length <numeric-range-viewer params="Range: EraLength"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtStart() != null -->
+	<li>with age at era start <numeric-range-viewer params="Range: AgeAtStart"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtEnd() != null -->
+	<li>with age at era end <numeric-range-viewer params="Range: AgeAtEnd"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/DrugExposure.js
+++ b/js/modules/cohortdefinitionviewer/components/DrugExposure.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./DrugExposureTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function DrugExposureViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.DrugExposure;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: DrugExposureViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/DrugExposure.js
+++ b/js/modules/cohortdefinitionviewer/components/DrugExposure.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/DrugExposureTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DrugExposureTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a drug exposure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a drug exposure of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Drug'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>
@@ -38,7 +38,7 @@ a drug exposure of <span data-bind="text: $component.getCodesetName(CodesetId(),
 	<li>with a lot number <text-filter-viewer params="Filter: LotNumber"></text-filter-viewer></li>
 <!-- /ko -->
 <!-- ko if: DrugSourceConcept() != null -->
-	<li>Drug Source Concept is <span data-bind="text: $component.getCodesetName(DrugSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Drug Source Concept is <conceptset-reference params="{conceptSetId: DrugSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: Age() != null -->
 	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/DrugExposureTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/DrugExposureTemplate.html
@@ -1,0 +1,56 @@
+<!-- ko with: Criteria -->
+a drug exposure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceEndDate() != null -->
+	<li>occurrence end is <date-range-viewer params="Range: OccurrenceEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: DrugType() != null -->
+	<li>drug type is any of: <concept-list-viewer params="ConceptList: DrugType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: StopReason() != null -->
+	<li>with a Stop Reason <text-filter-viewer params="Filter: StopReason"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: Refills() != null -->
+	<li>with refills <numeric-range-viewer params="Range: Refills"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Quantity() != null -->
+	<li>with quantity <numeric-range-viewer params="Range: Quantity"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: DaysSupply() != null -->
+	<li>with days supply <numeric-range-viewer params="Range: DaysSupply"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: RouteConcept() != null -->
+	<li>route concept is any of: <concept-list-viewer params="ConceptList: RouteConcept()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: EffectiveDrugDose() != null -->
+	<li>with effective drug dose <numeric-range-viewer params="Range: EffectiveDrugDose"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: DoseUnit() != null -->
+	<li>dose unit is any of: <concept-list-viewer params="ConceptList: DoseUnit()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: LotNumber() != null -->
+	<li>with a lot number <text-filter-viewer params="Filter: LotNumber"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: DrugSourceConcept() != null -->
+	<li>Drug Source Concept is <span data-bind="text: $component.getCodesetName(DrugSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/Measurement.js
+++ b/js/modules/cohortdefinitionviewer/components/Measurement.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./MeasurementTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function MeasurementViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.Measurement;
+		self.options = options;
+	
+		self.getCodesetName = function(codesetId, defaultName) {
+		if (codesetId != null)	
+			return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+		else
+			return defaultName;
+		};
+	
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: MeasurementViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/Measurement.js
+++ b/js/modules/cohortdefinitionviewer/components/Measurement.js
@@ -8,10 +8,13 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 	
 		self.getCodesetName = function(codesetId, defaultName) {
-		if (codesetId != null)	
-			return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
-		else
-			return defaultName;
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
+			else
+				return defaultName;
 		};
 	
 	}

--- a/js/modules/cohortdefinitionviewer/components/MeasurementTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/MeasurementTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a measurement of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Measurement')"></span>
+a measurement of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Measurement'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>
@@ -38,7 +38,7 @@ a measurement of <span data-bind="text: $component.getCodesetName(CodesetId(), '
 	<li>with an abnormal result</li>
 <!-- /ko -->
 <!-- ko if: MeasurementSourceConcept() != null -->
-	<li>Measurement Source Concept is <span data-bind="text: $component.getCodesetName(MeasurementSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Measurement Source Concept is <conceptset-reference params="{conceptSetId: MeasurementSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: Age() != null -->
 	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/MeasurementTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/MeasurementTemplate.html
@@ -1,0 +1,56 @@
+<!-- ko with: Criteria -->
+a measurement of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Measurement')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: MeasurementType() != null -->
+	<li>measurement type is any of: <concept-list-viewer params="ConceptList: MeasurementType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Operator() != null -->
+	<li>measurement value operator is any of: <concept-list-viewer params="ConceptList: Operator()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ValueAsNumber() != null -->
+	<li>with value as number <numeric-range-viewer params="Range: ValueAsNumber"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ValueAsConcept() != null -->
+	<li>value as concept is any of: <concept-list-viewer params="ConceptList: ValueAsConcept()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Unit() != null -->
+	<li>unit is any of: <concept-list-viewer params="ConceptList: Unit()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: RangeLow() != null -->
+	<li>with lower range <numeric-range-viewer params="Range: RangeLow"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: RangeLowRatio() != null -->
+	<li>with lower range ratio <numeric-range-viewer params="Range: RangeLowRatio"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: RangeHigh() != null -->
+	<li>with high range <numeric-range-viewer params="Range: RangeHigh"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: RangeHighRatio() != null -->
+	<li>with high range ratio <numeric-range-viewer params="Range: RangeHighRatio"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Abnormal() != null -->
+	<li>with an abnormal result</li>
+<!-- /ko -->
+<!-- ko if: MeasurementSourceConcept() != null -->
+	<li>Measurement Source Concept is <span data-bind="text: $component.getCodesetName(MeasurementSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/NumericRange.js
+++ b/js/modules/cohortdefinitionviewer/components/NumericRange.js
@@ -1,0 +1,44 @@
+define(['knockout', 'text!./NumericRangeTemplate.html'], function (ko, componentTemplate) {
+
+	function NumericRangeViewModel(params) {
+		var self = this;
+		self.Range = params.Range; // this will be a NumericRange input type.
+		
+		self.operationOptions = [{
+			id: 'lt',
+			name: '<'
+		}, {
+			id: 'lte',
+			name: '<='
+		}, {
+			id: 'eq',
+			name: '='
+		}, {
+			id: 'gt',
+			name: '>'
+		}, {
+			id: 'gte',
+			name: '>='
+		}, {
+			id: 'bt',
+			name: 'between'
+		}, {
+			id: '!bt',
+			name: 'not Between'
+		}];
+
+		self.rangeOpName = ko.pureComputed(function() {
+			return self.operationOptions.filter(function(item) {
+				return item.id == self.Range().Op();
+			})[0].name;
+		});
+
+	};
+
+	// return compoonent definition
+	return {
+		viewModel: NumericRangeViewModel,
+		template: componentTemplate
+	};
+
+});

--- a/js/modules/cohortdefinitionviewer/components/NumericRangeTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/NumericRangeTemplate.html
@@ -1,0 +1,1 @@
+<span class="readOnlyField" data-bind="text: rangeOpName"></span> <span class="readOnlyField" data-bind="text: Range().Value"></span><span data-bind="if: Range().Op().substr(-2) == 'bt'"> and <span class="readOnlyField" data-bind="text: Range().Extent"></span>

--- a/js/modules/cohortdefinitionviewer/components/Observation.js
+++ b/js/modules/cohortdefinitionviewer/components/Observation.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/Observation.js
+++ b/js/modules/cohortdefinitionviewer/components/Observation.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./ObservationTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function ObservationViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.Observation;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: ObservationViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ObservationPeriod.js
+++ b/js/modules/cohortdefinitionviewer/components/ObservationPeriod.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 		
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/ObservationPeriod.js
+++ b/js/modules/cohortdefinitionviewer/components/ObservationPeriod.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'text!./ObservationPeriodTemplate.html'], function (ko, options, Range, template) {
+
+	function ObservationPeriodViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.ObservationPeriod;
+		self.options = options;
+		
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: ObservationPeriodViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ObservationPeriodTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ObservationPeriodTemplate.html
@@ -1,0 +1,26 @@
+<!-- ko with: Criteria -->
+an observation period
+<ul>
+<!-- ko if: First() != null -->
+	<li>limited to the patients first observation period</li>
+<!-- /ko -->
+<!-- ko if: PeriodStartDate() != null -->
+	<li>period start is <date-range-viewer params="Range: PeriodStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: PeriodEndDate() != null -->
+	<li>period end is <date-range-viewer params="Range: PeriodEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: PeriodType() != null -->
+	<li>period type is any of: <concept-list-viewer params="ConceptList: PeriodType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: PeriodLength() != null -->
+	<li>with period duration <numeric-range-viewer params="Range: PeriodLength"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtStart() != null -->
+	<li>with age at period start <numeric-range-viewer params="Range: AgeAtStart"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: AgeAtEnd() != null -->
+	<li>with age at period end <numeric-range-viewer params="Range: AgeAtEnd"></numeric-range-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/ObservationTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ObservationTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-an observation of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Observation')"></span>
+an observation of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Observation'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/ObservationTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ObservationTemplate.html
@@ -1,0 +1,41 @@
+<!-- ko with: Criteria -->
+an observation of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Observation')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ObservationType() != null -->
+	<li>observation type is any of: <concept-list-viewer params="ConceptList: ObservationType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ValueAsNumber() != null -->
+	<li>with value as number <numeric-range-viewer params="Range: ValueAsNumber"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ValueAsString() != null -->
+	<li>with value as string <text-filter-viewer params="Filter: ValueAsString"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: ValueAsConcept() != null -->
+	<li>value as concept is any of: <concept-list-viewer params="ConceptList: ValueAsConcept()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Qualifier() != null -->
+	<li>qualifier is any of: <concept-list-viewer params="ConceptList: Qualifier()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Unit() != null -->
+	<li>unit is any of: <concept-list-viewer params="ConceptList: Unit()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/ProcedureOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/ProcedureOccurrence.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/ProcedureOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/ProcedureOccurrence.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./ProcedureOccurrenceTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function ProcedureOccurrenceViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.ProcedureOccurrence;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: ProcedureOccurrenceViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/ProcedureOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ProcedureOccurrenceTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a procedure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a procedure of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Procedure'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>
@@ -17,7 +17,7 @@ a procedure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'An
 	<li>with quantity <numeric-range-viewer params="Range: Quantity"></numeric-range-viewer></li>
 <!-- /ko -->
 <!-- ko if: ProcedureSourceConcept() != null -->
-	<li>Procedure Source Concept is <span data-bind="text: $component.getCodesetName(ProcedureSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Procedure Source Concept is <conceptset-reference params="{conceptSetId: ProcedureSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: Age() != null -->
 	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/ProcedureOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/ProcedureOccurrenceTemplate.html
@@ -1,0 +1,35 @@
+<!-- ko with: Criteria -->
+a procedure of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProcedureType() != null -->
+	<li>procedure type is any of: <concept-list-viewer params="ConceptList: ProcedureType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Modifier() != null -->
+	<li>modifier is any of: <concept-list-viewer params="ConceptList: Modifier()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Quantity() != null -->
+	<li>with quantity <numeric-range-viewer params="Range: Quantity"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProcedureSourceConcept() != null -->
+	<li>Procedure Source Concept is <span data-bind="text: $component.getCodesetName(ProcedureSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit occurrance is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/Specimen.js
+++ b/js/modules/cohortdefinitionviewer/components/Specimen.js
@@ -1,0 +1,23 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'cohortbuilder/InputTypes/Text', 'text!./SpecimenTemplate.html'], function (ko, options, Range, Text, template) {
+
+	function SpecimenViewModel(params) {
+		var self = this;
+		self.expression = params.expression;
+		self.Criteria = params.criteria.Specimen;
+		self.options = options;
+		
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: SpecimenViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/Specimen.js
+++ b/js/modules/cohortdefinitionviewer/components/Specimen.js
@@ -7,8 +7,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 		
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/SpecimenTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/SpecimenTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a a specimen of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a a specimen of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Specimen'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>

--- a/js/modules/cohortdefinitionviewer/components/SpecimenTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/SpecimenTemplate.html
@@ -1,0 +1,35 @@
+<!-- ko with: Criteria -->
+a a specimen of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: SpecimenType() != null -->
+	<li>specimen type is any of: <concept-list-viewer params="ConceptList: SpecimenType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: Quantity() != null -->
+	<li>with quantity <numeric-range-viewer params="Range: Quantity"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Unit() != null -->
+	<li>unit is any of: <concept-list-viewer params="ConceptList: Unit()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: AnatomicSite() != null -->
+	<li>anatomic site is any of: <concept-list-viewer params="ConceptList: AnatomicSite()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: DiseaseStatus() != null -->
+	<li>disease status is any of: <concept-list-viewer params="ConceptList: DiseaseStatus()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: SourceId() != null -->
+	<li>with a source ID <text-filter-viewer params="Filter: SourceId"></text-filter-viewer></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/TextFilter.js
+++ b/js/modules/cohortdefinitionviewer/components/TextFilter.js
@@ -1,0 +1,41 @@
+define(['knockout', 'text!./TextFilterTemplate.html'], function (ko, componentTemplate) {
+
+	function TextFilterViewModel(params) {
+		var self = this;
+		self.Filter = params.Filter; // this will be a Text input type.
+		
+		self.operationOptions = [{
+			id: 'startsWith',
+			name: 'starting with'
+		}, {
+			id: 'contains',
+			name: 'containing'
+		}, {
+			id: 'endsWith',
+			name: 'ending with'
+		}, {
+			id: '!startsWith',
+			name: 'not starting with'
+		}, {
+			id: '!contains',
+			name: 'not containing'
+		}, {
+			id: '!endsWith',
+			name: 'not ending with'
+		}];
+		
+		self.opName = ko.pureComputed(function() {
+			return self.operationOptions.filter(function(item) {
+				return item.id == self.Filter().Op();
+			})[0].name;
+		});
+		
+	};
+
+	// return compoonent definition
+	return {
+		viewModel: TextFilterViewModel,
+		template: componentTemplate
+	};
+
+});

--- a/js/modules/cohortdefinitionviewer/components/TextFilterTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/TextFilterTemplate.html
@@ -1,0 +1,1 @@
+<span class="readOnlyField" data-bind="text: opName"></span> "<span class="readOnlyField" data-bind="text: Filter().Text"></span>"

--- a/js/modules/cohortdefinitionviewer/components/VisitOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/VisitOccurrence.js
@@ -8,8 +8,11 @@ define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', '
 		self.options = options;
 
 		self.getCodesetName = function(codesetId, defaultName) {
-			if (codesetId != null)	
-				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			if (codesetId != null)
+			{
+				var selectedConceptSet = self.expression.ConceptSets().filter(function (item) { return item.id == codesetId })[0];
+				return ko.utils.unwrapObservable(selectedConceptSet.name);
+			}
 			else
 				return defaultName;
 		};

--- a/js/modules/cohortdefinitionviewer/components/VisitOccurrence.js
+++ b/js/modules/cohortdefinitionviewer/components/VisitOccurrence.js
@@ -1,0 +1,24 @@
+define(['knockout', 'cohortbuilder/options', 'cohortbuilder/InputTypes/Range', 'text!./VisitOccurrenceTemplate.html'], function (ko, options, Range, template) {
+
+	function VisitOccurrenceViewModel(params) {
+		var self = this;
+
+		self.expression = params.expression;
+		self.Criteria = params.criteria.VisitOccurrence;
+		self.options = options;
+
+		self.getCodesetName = function(codesetId, defaultName) {
+			if (codesetId != null)	
+				return ko.utils.unwrapObservable(self.expression.ConceptSets()[codesetId].name);
+			else
+				return defaultName;
+		};
+		
+	}
+
+	// return compoonent definition
+	return {
+		viewModel: VisitOccurrenceViewModel,
+		template: template
+	};
+});

--- a/js/modules/cohortdefinitionviewer/components/VisitOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/VisitOccurrenceTemplate.html
@@ -1,5 +1,5 @@
 <!-- ko with: Criteria -->
-a visit occurrence of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+a visit occurrence of <conceptset-reference params="{conceptSetId: CodesetId, conceptSets: $component.expression.ConceptSets, defaultName: 'Any Visit'}"></conceptset-reference>
 <ul>
 <!-- ko if: First() != null -->
 	<li>for the first time in the person's history</li>
@@ -14,7 +14,7 @@ a visit occurrence of <span data-bind="text: $component.getCodesetName(CodesetId
 	<li>visit type is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
 <!-- /ko -->
 <!-- ko if: VisitSourceConcept() != null -->
-	<li>Visit Source Concept is <span data-bind="text: $component.getCodesetName(VisitSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+	<li>Visit Source Concept is <conceptset-reference params="{conceptSetId: VisitSourceConcept(), conceptSets: $component.expression.ConceptSets, defaultName: 'UNSPECIFIED!'}"></conceptset-reference></li>
 <!-- /ko -->
 <!-- ko if: VisitLength() != null -->
 	<li>with visit length <numeric-range-viewer params="Range: VisitLength"></numeric-range-viewer></li>

--- a/js/modules/cohortdefinitionviewer/components/VisitOccurrenceTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/VisitOccurrenceTemplate.html
@@ -1,0 +1,32 @@
+<!-- ko with: Criteria -->
+a visit occurrence of <span data-bind="text: $component.getCodesetName(CodesetId(), 'Any Drug')"></span>
+<ul>
+<!-- ko if: First() != null -->
+	<li>for the first time in the person's history</li>
+<!-- /ko -->
+<!-- ko if: OccurrenceStartDate() != null -->
+	<li>occurrence start is <date-range-viewer params="Range: OccurrenceStartDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: OccurrenceEndDate() != null -->
+	<li>occurrence end is <date-range-viewer params="Range: OccurrenceEndDate"></date-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: VisitType() != null -->
+	<li>visit type is any of: <concept-list-viewer params="ConceptList: VisitType()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: VisitSourceConcept() != null -->
+	<li>Visit Source Concept is <span data-bind="text: $component.getCodesetName(VisitSourceConcept()(), 'UNSPECIFIED!')"></span></li>
+<!-- /ko -->
+<!-- ko if: VisitLength() != null -->
+	<li>with visit length <numeric-range-viewer params="Range: VisitLength"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Age() != null -->
+	<li>with age <numeric-range-viewer params="Range: Age"></numeric-range-viewer></li>
+<!-- /ko -->
+<!-- ko if: Gender() != null -->
+	<li>gender is any of: <concept-list-viewer params="ConceptList: Gender()"></concept-list-viewer></li>
+<!-- /ko -->
+<!-- ko if: ProviderSpecialty() != null -->
+	<li>provider specialty is any of: <concept-list-viewer params="ConceptList: ProviderSpecialty()"></concept-list></li>
+<!-- /ko -->
+</ul>
+<!-- /ko -->

--- a/js/modules/cohortdefinitionviewer/components/WindowInput.js
+++ b/js/modules/cohortdefinitionviewer/components/WindowInput.js
@@ -1,0 +1,22 @@
+define(['knockout', 'cohortbuilder/options', 'text!./WindowInputTemplate.html'], function (ko, options, template) {
+
+	function WindowInputViewModel(params) {
+		var self = this;
+		self.options = options;
+		self.Window = params.Window; // this will be a Window input type.
+		
+		self.getCoeffName = function(coeffId) {
+			return self.options.windowCoeffOptions.filter(function(item) {
+				return item.value == coeffId;
+			})[0].name;
+		};
+		
+	}
+	
+	// return compoonent definition
+	return {
+		viewModel: WindowInputViewModel,
+		template: template
+	};
+
+});

--- a/js/modules/cohortdefinitionviewer/components/WindowInputTemplate.html
+++ b/js/modules/cohortdefinitionviewer/components/WindowInputTemplate.html
@@ -1,0 +1,2 @@
+<span data-bind="text: Window.Start.Days() != null ? Window.Start.Days() : 'all'" /> days <span data-bind="text: $component.getCoeffName(Window.Start.Coeff())"></span>
+and <span data-bind="text: Window.End.Days() != null ? Window.End.Days() : 'all'" /> days <span data-bind="text: $component.getCoeffName(Window.End.Coeff())"></span>

--- a/js/modules/cohortdefinitionviewer/main.js
+++ b/js/modules/cohortdefinitionviewer/main.js
@@ -62,4 +62,10 @@ define(function (require, exports) {
 	var conceptList = require('./components/ConceptList');
 	ko.components.register('concept-list-viewer',conceptList);
 	
+	var conceptSetReference = require('./components/ConceptSetReference');
+	ko.components.register('conceptset-reference',conceptSetReference);
+	
+	var conceptSetViewer = require('./components/ConceptSetViewer');
+	ko.components.register('conceptset-viewer',conceptSetViewer);
+
 });

--- a/js/modules/cohortdefinitionviewer/main.js
+++ b/js/modules/cohortdefinitionviewer/main.js
@@ -1,0 +1,65 @@
+define(function (require, exports) {
+	
+	var ko = require('knockout')
+	
+	var expressionViewer = require('./components/CohortExpressionViewer');
+	ko.components.register('cohort-expression-viewer', expressionViewer);
+	
+	var criteriaGroup = require('./components/CriteriaGroup');
+	ko.components.register('criteria-group-viewer', criteriaGroup);
+
+	var conditionOccurrence = require('./components/ConditionOccurrence');
+	ko.components.register('condition-occurrence-criteria-viewer', conditionOccurrence);
+
+	var conditionEra = require('./components/ConditionEra');
+	ko.components.register('condition-era-criteria-viewer', conditionEra);
+
+	var drugExposure = require('./components/DrugExposure');
+	ko.components.register('drug-exposure-criteria-viewer', drugExposure);
+
+	var drugEra = require('./components/DrugEra');
+	ko.components.register('drug-era-criteria-viewer', drugEra);	
+	
+	var doseEra = require('./components/DoseEra');
+	ko.components.register('dose-era-criteria-viewer', doseEra);
+	
+	var procedureOccurrence = require('./components/ProcedureOccurrence');
+	ko.components.register('procedure-occurrence-criteria-viewer', procedureOccurrence);
+	
+	var observation = require('./components/Observation');
+	ko.components.register('observation-criteria-viewer', observation);
+	
+	var visitOccurrence = require('./components/VisitOccurrence');
+	ko.components.register('visit-occurrence-criteria-viewer', visitOccurrence);
+	
+	var deviceExposure = require('./components/DeviceExposure');
+	ko.components.register('device-exposure-criteria-viewer', deviceExposure);
+
+	var measurement = require('./components/Measurement');
+	ko.components.register('measurement-criteria-viewer', measurement);
+
+	var observationPeriod = require('./components/ObservationPeriod');
+	ko.components.register('observation-period-criteria-viewer', observationPeriod);
+
+	var specimen = require('./components/Specimen');
+	ko.components.register('specimen-criteria-viewer', specimen);
+	
+	var death = require('./components/Death');
+	ko.components.register('death-criteria-viewer', death);
+	
+	var numericRange = require('./components/NumericRange');
+	ko.components.register('numeric-range-viewer', numericRange);
+
+	var dateRange = require('./components/DateRange');
+	ko.components.register('date-range-viewer', dateRange);
+	
+	var windowInput = require('./components/WindowInput');
+	ko.components.register('window-input-viewer',windowInput);
+	
+	var textFilter = require('./components/TextFilter');
+	ko.components.register('text-filter-viewer',textFilter);	
+	
+	var conceptList = require('./components/ConceptList');
+	ko.components.register('concept-list-viewer',conceptList);
+	
+});

--- a/js/modules/conceptsetbuilder/components/ConceptSetBuilder.js
+++ b/js/modules/conceptsetbuilder/components/ConceptSetBuilder.js
@@ -5,15 +5,15 @@ define([
 	'../InputTypes/ConceptSet',
 	'../InputTypes/ConceptSetItem',
 	'databindings',
-	'conceptpicker/ConceptPicker'],
-	function (
+	'conceptpicker/ConceptPicker'
+], function (
 		$,
 		ko,
 		template,
 		ConceptSet,
 		ConceptSetItem) {
 
-		function CodesetBuilderViewModel(params) {
+	function CodesetBuilderViewModel(params) {
 			var self = this;
 
 			self.conceptSets = params.conceptSets;

--- a/js/modules/conceptsetbuilder/components/ConceptSetBuilderTemplate.html
+++ b/js/modules/conceptsetbuilder/components/ConceptSetBuilderTemplate.html
@@ -1,5 +1,5 @@
 <template id="conceptSetTemplate">
-	<select data-bind="options: conceptSets, 
+	<select data-bind="options: conceptSets.sorted, 
 		optionsText: function(item) { return item.name }, 
 		optionsCaption: 'Please select codeset to modify...', 
 		value: selectedConceptSet" class="mediumInputField">


### PR DESCRIPTION
This PR will introduce a new component into CIRCE: the cohort definition Viewer. This is a very simple view of the cohort definition structure, designed to be easily copy-pasted into tools that understand HTML->native format (such as HTML-> word).  Included in the view is each concept set expression referenced, and a series of tables created to describe each concept set in the expression.
